### PR TITLE
Add basic support to Position Pattern

### DIFF
--- a/Igor.xcodeproj/project.pbxproj
+++ b/Igor.xcodeproj/project.pbxproj
@@ -37,6 +37,14 @@
 		2DCE893715193E8900B975EE /* DEChainParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCE893515193E8900B975EE /* DEChainParser.m */; };
 		2DCE893B15193F6100B975EE /* DEInstanceParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCE893915193F6100B975EE /* DEInstanceParser.h */; };
 		2DCE893C15193F6100B975EE /* DEInstanceParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DCE893A15193F6100B975EE /* DEInstanceParser.m */; };
+		54AC483717BB1E7B007B0BB4 /* DEPositionParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 54AC483517BB1E7B007B0BB4 /* DEPositionParser.h */; };
+		54AC483817BB1E7B007B0BB4 /* DEPositionParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483617BB1E7B007B0BB4 /* DEPositionParser.m */; };
+		54AC483B17BB1FE1007B0BB4 /* DEPositionMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 54AC483917BB1FE1007B0BB4 /* DEPositionMatcher.h */; };
+		54AC483C17BB1FE1007B0BB4 /* DEPositionMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */; };
+		54AC483E17BB32B9007B0BB4 /* PositionMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483D17BB32B9007B0BB4 /* PositionMatcherTests.m */; };
+		54C9DBFD17BB227E00902BF2 /* PositionParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C9DBFB17BB227E00902BF2 /* PositionParserTests.m */; };
+		54C9DBFE17BB239D00902BF2 /* DEPositionParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483617BB1E7B007B0BB4 /* DEPositionParser.m */; };
+		54C9DBFF17BB23A200902BF2 /* DEPositionMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */; };
 		E621659DB794A5D612DCD443 /* DEQueryScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = E621659DB794A5D612DCD442 /* DEQueryScanner.m */; };
 		E621659DB794A5D612DCD445 /* DEQueryScanner.h in Headers */ = {isa = PBXBuildFile; fileRef = E621659DB794A5D612DCD444 /* DEQueryScanner.h */; };
 		E621659DB794A5D612DCD449 /* DEChainMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = E621659DB794A5D612DCD448 /* DEChainMatcher.h */; };
@@ -165,6 +173,12 @@
 		2DCE893915193F6100B975EE /* DEInstanceParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DEInstanceParser.h; sourceTree = "<group>"; };
 		2DCE893A15193F6100B975EE /* DEInstanceParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DEInstanceParser.m; sourceTree = "<group>"; };
 		2DCF9766147ED3FD003B0F38 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		54AC483517BB1E7B007B0BB4 /* DEPositionParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DEPositionParser.h; sourceTree = "<group>"; };
+		54AC483617BB1E7B007B0BB4 /* DEPositionParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DEPositionParser.m; sourceTree = "<group>"; };
+		54AC483917BB1FE1007B0BB4 /* DEPositionMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DEPositionMatcher.h; sourceTree = "<group>"; };
+		54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DEPositionMatcher.m; sourceTree = "<group>"; };
+		54AC483D17BB32B9007B0BB4 /* PositionMatcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PositionMatcherTests.m; sourceTree = "<group>"; };
+		54C9DBFB17BB227E00902BF2 /* PositionParserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PositionParserTests.m; sourceTree = "<group>"; };
 		E621659DB794A5D612DCD425 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E621659DB794A5D612DCD437 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		E621659DB794A5D612DCD439 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -378,6 +392,7 @@
 				E621659DB794A5D612DCD4AB /* DescendantCombinatorTests.m */,
 				E621659DB794A5D612DCD4DD /* ChildCombinatorTests.m */,
 				E621659DB794A5D612DCD474 /* BranchMatcherTests.m */,
+				54AC483D17BB32B9007B0BB4 /* PositionMatcherTests.m */,
 			);
 			path = matchers;
 			sourceTree = "<group>";
@@ -392,6 +407,7 @@
 				E621659DB794A5D612DCD504 /* CombinatorParserTests.m */,
 				E621659DB794A5D612DCD46C /* ClassParserTests.m */,
 				E621659DB794A5D612DCD4B5 /* ChainParserTests.m */,
+				54C9DBFB17BB227E00902BF2 /* PositionParserTests.m */,
 			);
 			path = parser;
 			sourceTree = "<group>";
@@ -436,6 +452,8 @@
 				E621659DB794A5D612DCD448 /* DEChainMatcher.h */,
 				E621659DB794A5D612DCD478 /* DEBranchMatcher.m */,
 				E621659DB794A5D612DCD47A /* DEBranchMatcher.h */,
+				54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */,
+				54AC483917BB1FE1007B0BB4 /* DEPositionMatcher.h */,
 			);
 			path = matchers;
 			sourceTree = "<group>";
@@ -464,6 +482,8 @@
 				2DCE893415193E8900B975EE /* DEChainParser.h */,
 				E621659DB794A5D612DCD499 /* DEBranchParser.m */,
 				E621659DB794A5D612DCD49B /* DEBranchParser.h */,
+				54AC483617BB1E7B007B0BB4 /* DEPositionParser.m */,
+				54AC483517BB1E7B007B0BB4 /* DEPositionParser.h */,
 			);
 			path = parser;
 			sourceTree = "<group>";
@@ -484,6 +504,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				54AC483717BB1E7B007B0BB4 /* DEPositionParser.h in Headers */,
 				2D9649E2147DA21400C40219 /* Igor-Prefix.pch in Headers */,
 				2D496EA51486A513007E1FDE /* DEPredicateMatcher.h in Headers */,
 				2DCE893615193E8900B975EE /* DEChainParser.h in Headers */,
@@ -508,6 +529,7 @@
 				E621659DB794A5D612DCD4EC /* DEKindOfClassMatcher.h in Headers */,
 				E621659DB794A5D612DCD4ED /* DEMatcher.h in Headers */,
 				E621659DB794A5D612DCD4EE /* DEMemberOfClassMatcher.h in Headers */,
+				54AC483B17BB1FE1007B0BB4 /* DEPositionMatcher.h in Headers */,
 				E621659DB794A5D612DCD4EF /* DEIgor.h in Headers */,
 				E621659DB794A5D612DCD4F7 /* DEIdentifierMatcher.h in Headers */,
 				E621659DB794A5D612DCD4FB /* DEIdentifierParser.h in Headers */,
@@ -604,6 +626,7 @@
 				2D695CDA147CD1D200AF4115 /* KindOfClassMatcherTests.m in Sources */,
 				2D695CDB147CD1D200AF4115 /* MemberOfClassMatcherTests.m in Sources */,
 				2D695CDD147CD1D200AF4115 /* PredicateParserTests.m in Sources */,
+				54AC483E17BB32B9007B0BB4 /* PositionMatcherTests.m in Sources */,
 				2D695CDE147CD1D200AF4115 /* PredicatePatternTests.m in Sources */,
 				2D3E1F3F1509B98200D62300 /* DescendantPatternTests.m in Sources */,
 				2D99DB351517E9C900244226 /* SubjectMarkerTests.m in Sources */,
@@ -655,6 +678,9 @@
 				E621659DB794A5D612DCD53A /* DEQueryScanner.m in Sources */,
 				E621659DB794A5D612DCD53B /* DEIgor.m in Sources */,
 				E621659DB794A5D612DCD53C /* DECombinatorParser.m in Sources */,
+				54C9DBFD17BB227E00902BF2 /* PositionParserTests.m in Sources */,
+				54C9DBFE17BB239D00902BF2 /* DEPositionParser.m in Sources */,
+				54C9DBFF17BB23A200902BF2 /* DEPositionMatcher.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -670,9 +696,11 @@
 				2D695CB7147CD1BA00AF4115 /* DEKindOfClassMatcher.m in Sources */,
 				2D695CBA147CD1BA00AF4115 /* DEMemberOfClassMatcher.m in Sources */,
 				2D695CC4147CD1BA00AF4115 /* DEPredicateParser.m in Sources */,
+				54AC483C17BB1FE1007B0BB4 /* DEPositionMatcher.m in Sources */,
 				2D496EA61486A513007E1FDE /* DEPredicateMatcher.m in Sources */,
 				2DCE893715193E8900B975EE /* DEChainParser.m in Sources */,
 				2DCE893C15193F6100B975EE /* DEInstanceParser.m in Sources */,
+				54AC483817BB1E7B007B0BB4 /* DEPositionParser.m in Sources */,
 				E621659DB794A5D612DCD443 /* DEQueryScanner.m in Sources */,
 				E621659DB794A5D612DCD45F /* DEUniversalMatcher.m in Sources */,
 				E621659DB794A5D612DCD479 /* DEBranchMatcher.m in Sources */,

--- a/Igor.xcodeproj/project.pbxproj
+++ b/Igor.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		54AC483B17BB1FE1007B0BB4 /* DEPositionMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 54AC483917BB1FE1007B0BB4 /* DEPositionMatcher.h */; };
 		54AC483C17BB1FE1007B0BB4 /* DEPositionMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */; };
 		54AC483E17BB32B9007B0BB4 /* PositionMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483D17BB32B9007B0BB4 /* PositionMatcherTests.m */; };
+		54AC484017BB37A4007B0BB4 /* PositionPatternTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483F17BB37A4007B0BB4 /* PositionPatternTests.m */; };
 		54C9DBFD17BB227E00902BF2 /* PositionParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C9DBFB17BB227E00902BF2 /* PositionParserTests.m */; };
 		54C9DBFE17BB239D00902BF2 /* DEPositionParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483617BB1E7B007B0BB4 /* DEPositionParser.m */; };
 		54C9DBFF17BB23A200902BF2 /* DEPositionMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */; };
@@ -178,6 +179,7 @@
 		54AC483917BB1FE1007B0BB4 /* DEPositionMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DEPositionMatcher.h; sourceTree = "<group>"; };
 		54AC483A17BB1FE1007B0BB4 /* DEPositionMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DEPositionMatcher.m; sourceTree = "<group>"; };
 		54AC483D17BB32B9007B0BB4 /* PositionMatcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PositionMatcherTests.m; sourceTree = "<group>"; };
+		54AC483F17BB37A4007B0BB4 /* PositionPatternTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PositionPatternTests.m; sourceTree = "<group>"; };
 		54C9DBFB17BB227E00902BF2 /* PositionParserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PositionParserTests.m; sourceTree = "<group>"; };
 		E621659DB794A5D612DCD425 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E621659DB794A5D612DCD437 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -347,6 +349,7 @@
 				2D695CCA147CD1D200AF4115 /* ClassPatternTests.m */,
 				E621659DB794A5D612DCD500 /* ChildPatternTests.m */,
 				E621659DB794A5D612DCD490 /* BranchPatternTests.m */,
+				54AC483F17BB37A4007B0BB4 /* PositionPatternTests.m */,
 			);
 			path = acceptance;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 				54C9DBFD17BB227E00902BF2 /* PositionParserTests.m in Sources */,
 				54C9DBFE17BB239D00902BF2 /* DEPositionParser.m in Sources */,
 				54C9DBFF17BB23A200902BF2 /* DEPositionMatcher.m in Sources */,
+				54AC484017BB37A4007B0BB4 /* PositionPatternTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Igor.xcodeproj/project.xcworkspace/xcshareddata/Igor.xccheckout
+++ b/Igor.xcodeproj/project.xcworkspace/xcshareddata/Igor.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>774B6FC9-4E79-4024-BFE0-29F379B370EC</string>
+	<key>IDESourceControlProjectName</key>
+	<string>Igor</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>B3806047-E9A6-404E-91F7-D509622D3412</key>
+		<string>ssh://github.com/siuying/igor.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>Igor.xcodeproj/project.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>B3806047-E9A6-404E-91F7-D509622D3412</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>ssh://github.com/siuying/igor.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>B3806047-E9A6-404E-91F7-D509622D3412</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>B3806047-E9A6-404E-91F7-D509622D3412</string>
+			<key>IDESourceControlWCCName</key>
+			<string>igor</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Igor.xcodeproj/xcshareddata/xcschemes/Igor.xcscheme
+++ b/Igor.xcodeproj/xcshareddata/xcschemes/Igor.xcscheme
@@ -14,7 +14,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E621659DB794A5D612DCD41D"
-               BuildableName = "libIgor-0.5.0.a"
+               BuildableName = "Igor"
                BlueprintName = "Igor"
                ReferencedContainer = "container:Igor.xcodeproj">
             </BuildableReference>

--- a/igor/engine/DEIgor.m
+++ b/igor/engine/DEIgor.m
@@ -7,6 +7,7 @@
 #import "DEPredicateParser.h"
 #import "DEBranchParser.h"
 #import "DEIdentifierParser.h"
+#import "DEPositionParser.h"
 #import "DEDescendantCombinator.h"
 #import "DEMatcher.h"
 
@@ -35,7 +36,8 @@
     id <DEPatternParser> classParser = [DEClassParser new];
     id <DEPatternParser> predicateParser = [DEPredicateParser new];
     id <DEPatternParser> identifierParser = [DEIdentifierParser new];
-    NSArray *simpleParsers = [NSArray arrayWithObjects:identifierParser, predicateParser, nil];
+    id <DEPatternParser> positionParser = [DEPositionParser new];
+    NSArray *simpleParsers = [NSArray arrayWithObjects:identifierParser, predicateParser, positionParser, nil];
     id <DEPatternParser> instanceParser = [DEInstanceParser parserWithClassParser:classParser simpleParsers:simpleParsers];
 
     id <DECombinatorParser> combinatorParser = [DECombinatorParser new];

--- a/igor/engine/DEIgor.m
+++ b/igor/engine/DEIgor.m
@@ -15,13 +15,13 @@
 }
 
 - (NSArray *)findViewsThatMatchMatcher:(id <DEMatcher>)matcher inTree:(UIView *)tree {
-    NSMutableSet *matchingViews = [NSMutableSet set];
+    NSMutableArray *matchingViews = [NSMutableArray array];
     NSMutableArray *allViews = [NSMutableArray arrayWithObject:tree];
     [allViews addObjectsFromArray:[[DEDescendantCombinator new] relativesOfView:tree]];
     for (UIView *view in allViews) {
         if ([matcher matchesView:view]) [matchingViews addObject:view];
     }
-    return [matchingViews allObjects];
+    return [[NSOrderedSet orderedSetWithArray:matchingViews] array];
 }
 
 - (NSArray *)findViewsThatMatchQuery:(NSString *)query inTree:(UIView *)tree {

--- a/igor/matchers/DEPositionMatcher.h
+++ b/igor/matchers/DEPositionMatcher.h
@@ -6,6 +6,7 @@
 @property (nonatomic, copy) NSString* position;
 
 - (instancetype)initWithPosition:(NSString *)position;
+
 - (BOOL)matchesView:(UIView *)view;
 
 + (DEPositionMatcher *)matcherForPosition:(NSString*)position;

--- a/igor/matchers/DEPositionMatcher.h
+++ b/igor/matchers/DEPositionMatcher.h
@@ -1,0 +1,13 @@
+#import "DEChainMatcher.h"
+#import "DEMatcher.h"
+
+@interface DEPositionMatcher : NSObject <DEChainMatcher>
+
+@property (nonatomic, copy) NSString* position;
+
+- (instancetype)initWithPosition:(NSString *)position;
+- (BOOL)matchesView:(UIView *)view;
+
++ (DEPositionMatcher *)matcherForPosition:(NSString*)position;
+
+@end

--- a/igor/matchers/DEPositionMatcher.m
+++ b/igor/matchers/DEPositionMatcher.m
@@ -1,0 +1,80 @@
+//
+//  DEPositionMatcher.m
+//  Igor
+//
+//  Created by Chong Francis on 13年8月14日.
+//
+//
+
+#import "DEPositionMatcher.h"
+
+@interface DEPositionMatcher()
+@end
+
+@implementation DEPositionMatcher
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@":%@", self.position];
+}
+
+- (instancetype)initWithPosition:(NSString *)position {
+    self = [super init];
+    if (self) {
+        _position = [position copy];
+    }
+    return self;
+}
+
+- (void)appendCombinator:(id <DECombinator>)combinator matcher:(id <DEMatcher>)matcher {
+    
+}
+
+- (BOOL)matchesView:(UIView *)view {
+    if ([self.position isEqualToString:@"root"] && [self isRootView:view]) {
+        return YES;
+    }
+    
+    if ([self.position isEqualToString:@"empty"] && [self isEmptyView:view]) {
+        return YES;
+    }
+    
+    if ([self.position isEqualToString:@"first-child"] && [self isFirstChild:view]) {
+        return YES;
+    }
+
+    if ([self.position isEqualToString:@"last-child"] && [self isLastChild:view]) {
+        return YES;
+    }
+
+    if ([self.position isEqualToString:@"only-child"] && [self isOnlyChild:view]) {
+        return YES;
+    }
+
+    return NO;
+}
+
+- (BOOL) isRootView:(UIView *)view {
+    return view.superview == [UIApplication sharedApplication].keyWindow;
+}
+
+- (BOOL) isEmptyView:(UIView *)view {
+    return [view.subviews count] == 0;
+}
+
+- (BOOL) isFirstChild:(UIView *)view {
+    return view.superview && view.superview.subviews[0] == view;
+}
+
+- (BOOL) isLastChild:(UIView *)view {
+    return view.superview && [view.superview.subviews lastObject] == view;
+}
+
+- (BOOL) isOnlyChild:(UIView *)view {
+    return view.superview && view.superview.subviews.count == 1;
+}
+
++ (DEPositionMatcher *)matcherForPosition:(NSString*)position {
+    return [[DEPositionMatcher alloc] initWithPosition:position];
+}
+
+@end

--- a/igor/matchers/DEPositionMatcher.m
+++ b/igor/matchers/DEPositionMatcher.m
@@ -25,10 +25,6 @@
     return self;
 }
 
-- (void)appendCombinator:(id <DECombinator>)combinator matcher:(id <DEMatcher>)matcher {
-    
-}
-
 - (BOOL)matchesView:(UIView *)view {
     if ([self.position isEqualToString:@"root"] && [self isRootView:view]) {
         return YES;

--- a/igor/parser/DEIgorParserException.h
+++ b/igor/parser/DEIgorParserException.h
@@ -1,4 +1,4 @@
-@interface DEIgorParserException
+@interface DEIgorParserException : NSException
 
 + (NSException *)exceptionWithReason:(NSString *)reason scanner:(NSScanner *)scanner;
 

--- a/igor/parser/DEPositionParser.h
+++ b/igor/parser/DEPositionParser.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+#import "DEPatternParser.h"
+
+@interface DEPositionParser : NSObject <DEPatternParser>
+@end

--- a/igor/parser/DEPositionParser.m
+++ b/igor/parser/DEPositionParser.m
@@ -1,0 +1,33 @@
+#import "DEPositionParser.h"
+#import "DEQueryScanner.h"
+#import "DEUniversalMatcher.h"
+#import "DEPositionMatcher.h"
+
+static NSSet* _positionPatterns;
+
+@implementation DEPositionParser
+
++(void) initialize {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _positionPatterns = [NSSet setWithArray:@[@"empty", @"first-child", @"last-child", @"only-child"]];
+    });
+}
+
+- (id <DEMatcher>)parseMatcherFromScanner:(id <DEQueryScanner>)scanner {
+    if (![scanner skipString:@":"]) {
+        return nil;
+    }
+
+    NSString *expression;
+
+    if (![scanner scanPositionPatternIntoString:&expression])
+        [scanner failBecause:@"Expected a position pattern after the :"];
+    
+    if (![_positionPatterns containsObject:expression])
+        [scanner failBecause:[NSString stringWithFormat:@"Expected to be one of valid position pattern (%@)", _positionPatterns]];
+
+    return [DEPositionMatcher matcherForPosition:expression];
+}
+
+@end

--- a/igor/parser/DEPositionParser.m
+++ b/igor/parser/DEPositionParser.m
@@ -25,7 +25,7 @@ static NSSet* _positionPatterns;
         [scanner failBecause:@"Expected a position pattern after the :"];
     
     if (![_positionPatterns containsObject:expression])
-        [scanner failBecause:[NSString stringWithFormat:@"Expected to be one of valid position pattern (%@)", _positionPatterns]];
+        [scanner failBecause:[NSString stringWithFormat:@"Expected to be one of valid position pattern %@, get: %@", [_positionPatterns allObjects], [scanner description]]];
 
     return [DEPositionMatcher matcherForPosition:expression];
 }

--- a/igor/parser/DEQueryScanner.h
+++ b/igor/parser/DEQueryScanner.h
@@ -6,6 +6,8 @@
 
 - (BOOL)scanNameIntoString:(NSString **)destination;
 
+- (BOOL)scanPositionPatternIntoString:(NSString **)destination;
+
 - (BOOL)scanUpToString:(NSString *)string intoString:(NSString **)destination;
 
 - (BOOL)skipString:(NSString *)string;

--- a/igor/parser/DEQueryScanner.m
+++ b/igor/parser/DEQueryScanner.m
@@ -34,6 +34,12 @@
     return [self.scanner scanCharactersFromSet:nameCharacterSet intoString:destination];
 }
 
+- (BOOL)scanPositionPatternIntoString:(NSString **)destination {
+    NSMutableCharacterSet *positionCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
+    [positionCharacterSet addCharactersInString:@"-"];
+    return [self.scanner scanCharactersFromSet:positionCharacterSet intoString:destination];
+}
+
 + (id <DEQueryScanner>)scannerWithString:(NSString *)queryString {
     return [[self alloc] initWithString:queryString];
 }

--- a/test/acceptance/ClassPatternTests.m
+++ b/test/acceptance/ClassPatternTests.m
@@ -81,4 +81,21 @@
     assertThat(matchingViews, isNot(hasItem(viewOfUnrelatedClass)));
 }
 
+- (void)testMatchedSubviewsOrder {
+    NSString *query = @"UIButton";
+    
+    UIView *root = [ViewFactory viewWithName:@"root"];
+    UIButton *b1 = [ViewFactory button];
+    UIButton *b2 = [ViewFactory button];
+    UIButton *b3 = [ViewFactory button];
+    
+    [root addSubview:b1];
+    [root addSubview:b2];
+    [root addSubview:b3];
+    
+    NSArray *matchingViews = [igor findViewsThatMatchQuery:query inTree:root];
+    assertThat(matchingViews, containsInAnyOrder(b1, b2, b3, nil));
+    assertThat(matchingViews, equalTo(@[b1, b2, b3]));
+}
+
 @end

--- a/test/acceptance/PositionPatternTests.m
+++ b/test/acceptance/PositionPatternTests.m
@@ -70,6 +70,14 @@
 {
     NSArray *matchingViews = [igor findViewsThatMatchQuery:@"#root > :empty" inTree:view];
     assertThat(matchingViews, equalTo(@[button]));
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"*:empty" inTree:view];
+    assertThat(matchingViews, containsInAnyOrder(header.subviews[0], header.subviews[1], header.subviews[2],
+                                                 form.subviews[0], form.subviews[1], form.subviews[2],
+                                                 footer.subviews[0], button, nil));
+
+    matchingViews = [igor findViewsThatMatchQuery:@"UIView > :first-child > UIView:empty" inTree:view];
+    assertThat(matchingViews, containsInAnyOrder(header.subviews[0], header.subviews[1], header.subviews[2], nil));
 }
 
 - (void)testOnlyChild

--- a/test/acceptance/PositionPatternTests.m
+++ b/test/acceptance/PositionPatternTests.m
@@ -1,0 +1,87 @@
+#import "DEIgor.h"
+#import "ViewFactory.h"
+
+@interface PositionPatternTests : SenTestCase
+
+@end
+
+@implementation PositionPatternTests {
+    DEIgor *igor;
+    UIView *view;
+    UIView* header;
+    UIView* footer;
+    UIView* form;
+    UIButton* button;
+}
+
+- (void)setUp
+{
+    [super setUp];
+
+    igor = [DEIgor igor];
+    view = [ViewFactory viewWithName:@"root"];
+
+    header = [ViewFactory viewWithName:@"header"];
+    [header addSubview:[ViewFactory viewWithName:@"subview11"]];
+    [header addSubview:[ViewFactory viewWithName:@"subview12"]];
+    [header addSubview:[ViewFactory viewWithName:@"subview13"]];
+    [view addSubview:header];
+    
+    form = [ViewFactory viewWithName:@"form"];
+    [form addSubview:[ViewFactory viewWithName:@"subview21"]];
+    [form addSubview:[ViewFactory viewWithName:@"subview22"]];
+    [form addSubview:[ViewFactory viewWithName:@"subview23"]];
+    [view addSubview:form];
+
+    footer = [ViewFactory viewWithName:@"footer"];
+    [footer addSubview:[ViewFactory viewWithName:@"subview31"]];
+    [view addSubview:footer];
+
+    button = [ViewFactory button];
+    [view addSubview:button];
+    
+}
+
+- (void)testFirstChild
+{
+    NSArray *matchingViews = [igor findViewsThatMatchQuery:@"#header :first-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[header.subviews[0]]));
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#root > :first-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[header]));
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#root > UIView > :first-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[header.subviews[0], form.subviews[0], footer.subviews[0]]));
+}
+
+- (void)testLastChild
+{
+    NSArray *matchingViews = [igor findViewsThatMatchQuery:@"#header :last-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[header.subviews[2]]));
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#root > :last-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[button]));
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#root > UIView > :last-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[header.subviews[2], form.subviews[2], footer.subviews[0]]));
+}
+
+- (void)testEmpty
+{
+    NSArray *matchingViews = [igor findViewsThatMatchQuery:@"#root > :empty" inTree:view];
+    assertThat(matchingViews, equalTo(@[button]));
+}
+
+- (void)testOnlyChild
+{
+    NSArray *matchingViews = [igor findViewsThatMatchQuery:@"#header > :only-child" inTree:view];
+    assertThat(matchingViews, empty());
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#form > :only-child" inTree:view];
+    assertThat(matchingViews, empty());
+    
+    matchingViews = [igor findViewsThatMatchQuery:@"#footer > :only-child" inTree:view];
+    assertThat(matchingViews, equalTo(@[footer.subviews[0]]));
+}
+
+@end

--- a/test/matchers/PositionMatcherTests.m
+++ b/test/matchers/PositionMatcherTests.m
@@ -1,0 +1,52 @@
+#import "ViewFactory.h"
+#import "MatchesView.h"
+#import "DEMatcher.h"
+#import "DEIdentifierMatcher.h"
+#import "DEPositionMatcher.h"
+
+@interface PositionMatcherTests : SenTestCase
+
+@end
+
+@implementation PositionMatcherTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testExample
+{
+    UIView *root = [ViewFactory viewWithName:@"root"];
+    UIView *subview1 = [ViewFactory viewWithName:@"subview1"];
+    UIView *subview2 = [ViewFactory viewWithName:@"subview2"];
+    UIView *subview3 = [ViewFactory viewWithName:@"subview3"];
+    UIView *subview31 = [ViewFactory viewWithName:@"subview31"];
+    [root addSubview:subview1];
+    [root addSubview:subview2];
+    [root addSubview:subview3];
+    [subview3 addSubview:subview31];
+
+    id <DEMatcher> emptyMatcher = [DEPositionMatcher matcherForPosition:@"empty"];
+    assertThat(emptyMatcher, [MatchesView view:subview1]);
+    assertThat(emptyMatcher, isNot([MatchesView view:subview3]));
+
+    id <DEMatcher> firstChildMatcher = [DEPositionMatcher matcherForPosition:@"first-child"];
+    assertThat(firstChildMatcher, [MatchesView view:subview1]);
+    assertThat(firstChildMatcher, isNot([MatchesView view:subview3]));
+
+    id <DEMatcher> lastChildMatcher = [DEPositionMatcher matcherForPosition:@"last-child"];
+    assertThat(lastChildMatcher, [MatchesView view:subview3]);
+    assertThat(lastChildMatcher, isNot([MatchesView view:subview1]));
+    
+    id <DEMatcher> onlyChildMatcher = [DEPositionMatcher matcherForPosition:@"only-child"];
+    assertThat(onlyChildMatcher, [MatchesView view:subview31]);
+    assertThat(onlyChildMatcher, isNot([MatchesView view:subview3]));
+}
+
+@end

--- a/test/parser/PositionParserTests.m
+++ b/test/parser/PositionParserTests.m
@@ -19,8 +19,8 @@
 }
 
 - (void)testParsesPositionPatterns {
-    NSArray* patterns = @[@":root", @":empty", @":first-child", @":last-child", @":only-child"];
-    NSArray* position = @[@"root", @"empty", @"first-child", @"last-child", @"only-child"];
+    NSArray* patterns = @[@":empty", @":first-child", @":last-child", @":only-child"];
+    NSArray* position = @[@"empty", @"first-child", @"last-child", @"only-child"];
     [patterns enumerateObjectsUsingBlock:^(NSString *expression, NSUInteger idx, BOOL *stop) {
         scanner = [DEQueryScanner scannerWithString:expression];
         DEPositionMatcher* matcher = (DEPositionMatcher*) [parser parseMatcherFromScanner:scanner];

--- a/test/parser/PositionParserTests.m
+++ b/test/parser/PositionParserTests.m
@@ -1,0 +1,35 @@
+#import <SenTestingKit/SenTestingKit.h>
+#import "DEChainParser.h"
+#import "DEUniversalMatcher.h"
+#import "DEPositionParser.h"
+#import "DEMatcher.h"
+#import "DEPositionMatcher.h"
+#import "DEQueryScanner.h"
+
+@interface PositionParserTests : SenTestCase
+@end
+
+@implementation PositionParserTests {
+    DEQueryScanner* scanner;
+    DEPositionParser* parser;
+}
+
+- (void)setUp {
+    parser = [DEPositionParser new];
+}
+
+- (void)testParsesPositionPatterns {
+    NSArray* patterns = @[@":root", @":empty", @":first-child", @":last-child", @":only-child"];
+    NSArray* position = @[@"root", @"empty", @"first-child", @"last-child", @"only-child"];
+    [patterns enumerateObjectsUsingBlock:^(NSString *expression, NSUInteger idx, BOOL *stop) {
+        scanner = [DEQueryScanner scannerWithString:expression];
+        DEPositionMatcher* matcher = (DEPositionMatcher*) [parser parseMatcherFromScanner:scanner];
+        assertThat(matcher, instanceOf([DEPositionMatcher class]));
+        assertThat(matcher.position, equalTo(position[idx]));
+    }];
+
+    scanner = [DEQueryScanner scannerWithString:@":invalid"];
+    STAssertThrows([parser parseMatcherFromScanner:scanner], @"should failed with invalid pattern");
+}
+
+@end


### PR DESCRIPTION
This PR Implement following:
- Use ordered set when matching views, such that we keep the order information of matches
- Basic parser and matcher for basic position pattern: :first-child, :last-child, :empty, :only-child
- Fix DEIgorParserException compiler warning (#12)

I don't quite sure the definition of :root and others, so I'll leave them later.
